### PR TITLE
Allow to remove an asset before its full depreciation

### DIFF
--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -75,6 +75,10 @@ class account_asset_category(orm.Model):
             'account.account', 'Depreciation Account', required=True),
         'account_expense_depreciation_id': fields.many2one(
             'account.account', 'Depr. Expense Account', required=True),
+        'account_residual_asset_value_id': fields.many2one(
+            'account.account', 'Residual Value Account', required=True,
+            help="This account is only used if you remove an asset before "
+                 "it is fully depreciated."),
         'journal_id': fields.many2one(
             'account.journal', 'Journal', required=True),
         'company_id': fields.many2one(
@@ -813,6 +817,19 @@ class account_asset_asset(orm.Model):
             'target': 'new',
             'type': 'ir.actions.act_window',
             'context': dict(context, active_ids=ids, active_id=ids[0]),
+            'nodestroy': True,
+        }
+
+    def early_remove(self, cr, uid, ids, context=None):
+        return {
+            'name': _("Generate Asset Removal entries"),
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'account.asset.remove',
+            'target': 'new',
+            'type': 'ir.actions.act_window',
+            'context': dict(context, active_ids=ids, active_id=ids[0],
+                            early_removal=True),
             'nodestroy': True,
         }
 

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -79,6 +79,10 @@ class account_asset_category(orm.Model):
             'account.account', 'Residual Value Account', required=True,
             help="This account is only used if you remove an asset before "
                  "it is fully depreciated."),
+        'account_plus_value_asset_id': fields.many2one(
+            'account.account', 'Plus-Value Account',
+            help="This account is only used if you sell an asset "
+                 "before its removal"),
         'journal_id': fields.many2one(
             'account.journal', 'Journal', required=True),
         'company_id': fields.many2one(
@@ -1226,7 +1230,8 @@ class account_asset_asset(orm.Model):
         default.update({
             'depreciation_line_ids': [],
             'account_move_line_ids': [],
-            'state': 'draft'})
+            'state': 'draft',
+            'history_ids': []})
         return super(account_asset_asset, self).copy(
             cr, uid, id, default, context=context)
 

--- a/account_asset_management/account_asset_invoice.py
+++ b/account_asset_management/account_asset_invoice.py
@@ -86,6 +86,8 @@ class account_invoice_line(orm.Model):
     _columns = {
         'asset_category_id': fields.many2one(
             'account.asset.category', 'Asset Category'),
+        'asset_id': fields.many2one(
+            'account.asset.asset', 'Asset'),
     }
 
     def onchange_account_id(self, cr, uid, ids, product_id,

--- a/account_asset_management/account_asset_invoice_view.xml
+++ b/account_asset_management/account_asset_invoice_view.xml
@@ -30,7 +30,7 @@
       <field name="inherit_id" ref="account.invoice_form"/>
       <field name="arch" type="xml">
         <xpath expr="//field[@name='invoice_line']/tree/field[@name='quantity']" position="before">
-          <field name="asset_id" groups="account_asset_use_plusvalue"/>
+          <field name="asset_id" groups="account_asset_management.account_asset_use_plusvalue"/>
         </xpath>
       </field>
     </record>

--- a/account_asset_management/account_asset_invoice_view.xml
+++ b/account_asset_management/account_asset_invoice_view.xml
@@ -30,7 +30,7 @@
       <field name="inherit_id" ref="account.invoice_form"/>
       <field name="arch" type="xml">
         <xpath expr="//field[@name='invoice_line']/tree/field[@name='quantity']" position="before">
-          <field name="asset_id"/>
+          <field name="asset_id" groups="account_asset_use_plusvalue"/>
         </xpath>
       </field>
     </record>

--- a/account_asset_management/account_asset_invoice_view.xml
+++ b/account_asset_management/account_asset_invoice_view.xml
@@ -24,5 +24,16 @@
       </field>
     </record>
 
+    <record model="ir.ui.view" id="view_customer_invoice_asset">
+      <field name="name">account.invoice.customer.form</field>
+      <field name="model">account.invoice</field>
+      <field name="inherit_id" ref="account.invoice_form"/>
+      <field name="arch" type="xml">
+        <xpath expr="//field[@name='invoice_line']/tree/field[@name='quantity']" position="before">
+          <field name="asset_id"/>
+        </xpath>
+      </field>
+    </record>
+
   </data>
 </openerp>

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -21,7 +21,7 @@
               <field name="account_depreciation_id"/>
               <field name="account_expense_depreciation_id"/>
               <field name="account_residual_asset_value_id"/>
-              <field name="account_plus_value_asset_id"/>
+              <field name="account_plus_value_asset_id" groups="account_asset_use_plusvalue"/>
             </group>
             <group string="Depreciation Dates">
               <field name="method_time" on_change="onchange_method_time(method_time)"/>

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -21,7 +21,7 @@
               <field name="account_depreciation_id"/>
               <field name="account_expense_depreciation_id"/>
               <field name="account_residual_asset_value_id"/>
-              <field name="account_plus_value_asset_id" groups="account_asset_use_plusvalue"/>
+              <field name="account_plus_value_asset_id" groups="account_asset_management.account_asset_use_plusvalue"/>
             </group>
             <group string="Depreciation Dates">
               <field name="method_time" on_change="onchange_method_time(method_time)"/>

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -21,6 +21,7 @@
               <field name="account_depreciation_id"/>
               <field name="account_expense_depreciation_id"/>
               <field name="account_residual_asset_value_id"/>
+              <field name="account_plus_value_asset_id"/>
             </group>
             <group string="Depreciation Dates">
               <field name="method_time" on_change="onchange_method_time(method_time)"/>
@@ -198,6 +199,7 @@
               <page string="History">
                 <field name="account_move_line_ids" readonly="1">
                   <tree colors="red:state == 'draft';black:state == 'valid'" string="Journal Items">
+                    <field name="move_id"/>
                     <field name="journal_id"/>
                     <field name="period_id"/>
                     <field name="date"/>

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -20,6 +20,7 @@
               <field name="account_asset_id"/>
               <field name="account_depreciation_id"/>
               <field name="account_expense_depreciation_id"/>
+              <field name="account_residual_asset_value_id"/>
             </group>
             <group string="Depreciation Dates">
               <field name="method_time" on_change="onchange_method_time(method_time)"/>
@@ -77,6 +78,9 @@
             <button name="validate" states="draft" string="Confirm Asset" type="object" class="oe_highlight"/>
             <button name="set_to_draft" states="open,close" string="Set to Draft" type="object" groups="account.group_account_manager"/>
             <!-- <button name="set_to_close" states="open" string="Set to Close" type="object" class="oe_highlight"/> -->
+            <button name="early_remove" string="Early Removal" type="object" class="oe_highlight"
+                    attrs="{'invisible':['|',('method_time','!=','year'),('state','!=','open')]}"
+                    help="Generate the removal entries for a non-fully depreciated asset."/>
             <button name="remove" string="Set to Removed" type="object" groups="account.group_account_manager"
                     attrs="{'invisible':['|',('method_time','!=','year'),('state','!=','close')]}"
                     help="Generate the removal entries for a fully depreciated asset."/>

--- a/account_asset_management/security/account_asset_security.xml
+++ b/account_asset_management/security/account_asset_security.xml
@@ -16,5 +16,11 @@
             <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
         </record>
 
+    <record id="account_asset_use_plusvalue" model="res.groups">
+        <field name="name">Asset Plus-Value</field>
+        <field name="category_id" ref="base.module_category_accounting_and_finance"/>
+        <field name="comment">The user will have access to plus-value account and will be able to link an invoice line to an asset</field>
+    </record>
+
     </data>
 </openerp>

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -42,6 +42,7 @@ class account_asset_remove(orm.TransientModel):
             domain=[('state', '<>', 'done')],
             help="Keep empty to use the period of the removal ate."),
         'note': fields.text('Notes'),
+    }
 
     def remove(self, cr, uid, ids, context=None):
         asset_obj = self.pool.get('account.asset.asset')

--- a/account_asset_management/wizard/account_asset_remove_view.xml
+++ b/account_asset_management/wizard/account_asset_remove_view.xml
@@ -10,7 +10,7 @@
             <group colspan="4" col="2">
               <separator string="Specify the asset removal date" colspan="2"/>
               <field name="date_remove"/>
-              <field name="period_id"/>
+              <field name="period_id" invisible="context.get('early_removal', False)"/>
               <separator string="Notes" colspan="2"/>
               <field name="note" nolabel="1" colspan="2"/>
             </group>


### PR DESCRIPTION
The changes : 
- New account on asset category, used only when we remove an asset before it is fully depreciated
- add a button when an asset is opened to allow the antipated removal

If the user choose to do so, it will remove all depreciation lines which date is after the removal  date.
It will change the depreciation line corresponding to the removal date to adjust the amount and the date if we the boolean 'prorata temporis' is matched. (Else, it will remove it). Then validate automaticaly this modified depreciation line so it creates its account.move.line.
Finally, it will creates 3 removal account move line. The residual amount which could not be depreciated goes to the new account.

Note, the early removal date have to be after the last posted entry and during the first non-posted entry.

I make a merge proposal here so you can tell me what you think and ask if it is not clear.
I would gladly take your advices into consideration.
If you think merging this PR with yours would delay the merge into OCA branch, then I can propose this merge to OCA directly so it won't impact your PR.

Anyway, I would like to have your opinion.
