### PR TITLE
[IMP] account_asset_management: replace official config option.

### DIFF
--- a/account_asset_management/__openerp__.py
+++ b/account_asset_management/__openerp__.py
@@ -73,6 +73,7 @@ Contributors
         'account_view.xml',
         'account_asset_invoice_view.xml',
         'report/account_asset_report_view.xml',
+        'res_config_view.xml',
     ],
     'auto_install': False,
     'installable': True,

--- a/account_asset_management/res_config.py
+++ b/account_asset_management/res_config.py
@@ -3,9 +3,7 @@
 #
 #    OpenERP, Open Source Management Solution
 #
-#    Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>).
-#    Copyright (C) 2010-2012 OpenERP s.a. (<http://openerp.com>).
-#    Copyright (c) 2014 Noviat nv/sa (www.noviat.com). All rights reserved.
+#    Copyright (c) 2014 ACSONE SA/NV (http://acsone.eu).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -22,12 +20,18 @@
 #
 ##############################################################################
 
-from . import account_asset
-from . import account_asset_invoice
-from . import account
-from . import account_move
-from . import wizard
-from . import report
-from . import res_config
+from openerp.osv import orm, fields
 
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+
+class Config(orm.Model):
+    _inherit = 'account.config.settings'
+
+    _columns = {
+        'module_account_asset_management': fields.boolean(
+            'Assets management (OCA)',
+            help="""This allows you to manage the assets owned by a company
+                    or a person. It keeps track of the depreciation occurred
+                    on those assets, and creates account move for those
+                    depreciation lines.
+                    This installs the module account_asset_management."""),
+    }

--- a/account_asset_management/res_config_view.xml
+++ b/account_asset_management/res_config_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="view_account_config_settings">
+            <field name="name">account.config.settings.inherit</field>
+            <field name="inherit_id" ref="account.view_account_config_settings"/>
+            <field name="model">account.config.settings</field>
+            <field name="arch" type="xml">
+                <field name="module_account_asset" position="replace">
+                    <field name="module_account_asset_management" class="oe_inline"/>
+                </field>
+                <xpath expr="//label[@for='module_account_asset']" position="replace">
+                    <label for="module_account_asset_management"/>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
This prevents users clicking on the "enable assets management" option
and inadvertently installing account_asset.
